### PR TITLE
fix: Update Node.js setup action and npm cache configuration

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -84,7 +84,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: 'npm'
@@ -140,10 +140,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
         
     - name: Set up Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary
- Fixed npm cache configuration issues in GitHub Actions workflows
- Updated Node.js setup action for consistency

## Problem
GitHub Actions was showing error: "Some specified paths were not resolved, unable to cache dependencies"

## Solution
- Updated actions/setup-node from v3 to v4 across all workflows
- Added npm cache configuration to E2E tests setup with proper cache-dependency-path

## Testing
- CI/CD workflows should now properly cache npm dependencies
- This will improve build times and resolve cache warnings